### PR TITLE
Throw an exception if the targetGuid could not be found

### DIFF
--- a/XcodePostBuild.cs
+++ b/XcodePostBuild.cs
@@ -167,6 +167,9 @@ public static class XcodePostBuild
     private static void ProcessUnityDirectory(PBXProject pbx, string src, string dest, string projectPathPrefix)
     {
         var targetGuid = pbx.TargetGuidByName(XcodeProjectName);
+		if (string.IsNullOrEmpty(targetGuid)) {
+			throw new Exception( string.Format( "TargetGuid could not be found for '{0}'", XcodeProjectName) );
+		}
 
         // newFiles: array of file names in build output that do not exist in project.pbx manifest.
         // extraFiles: array of file names in project.pbx manifest that do not exist in build output.


### PR DESCRIPTION
There is a single point of failure if an XCode-Project differs with a minor camel-case-issue in the projectname vs. file- or directory-name.

The current version of XcodePostBuild.cs would retrieve an empty-String (or null) for the unfound target in PBX-file and would continue anyways without to tell the developer its root cause why the build process will fail.

My Pull Request will throw now an exception in such a case to tell the user what happened here.

It won't break any compatibility.