### PR TITLE
Add support Xcode 9.3, 9.4 and Unity 2018.1.6f

### DIFF
--- a/demo/unity/Assets/Scripts/Editor/XcodePostBuild.cs
+++ b/demo/unity/Assets/Scripts/Editor/XcodePostBuild.cs
@@ -267,7 +267,8 @@ public static class XcodePostBuild
         if (Application.unityVersion.StartsWith("2017.3.0f")
                 || Application.unityVersion.StartsWith("2017.3.1f")
                 || Application.unityVersion.StartsWith("2017.4.1f")
-                || Application.unityVersion.StartsWith("2017.4.2f"))
+                || Application.unityVersion.StartsWith("2017.4.2f")
+		        || Application.unityVersion.StartsWith("2018.1.6f"))
         {
             EditSplashScreenMM(Path.Combine(pathToBuiltProject, "Classes/UI/SplashScreen.mm"));
         }


### PR DESCRIPTION
This method is still working with the aforementioned Xcode and Unity version. Except for Vuforia SDK 7.2, I make short instruction in #89 . 